### PR TITLE
Added 'compiler.json' description file and other minor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GEN_DIR := gen
 SRC_DIR := src
 MATJUICE_JAR := matjuice.jar
 MATJUICE_SH := matjuice.sh
-MCLAB_CORE_PATH ?= $(HOME)/workspace/mclab-core
+MCLAB_CORE_PATH ?= $(shell pwd)/deps/mclab-core
 NATLAB_PATH := $(MCLAB_CORE_PATH)/languages/Natlab
 
 define MATJUICE_SCRIPT
@@ -18,7 +18,7 @@ JSAST_FILES	 := src/matjuice/jsast/Javascript.ast src/matjuice/jsast/JavascriptP
 PRETTY_FILES	 := src/matjuice/pretty/*.java
 SRC_FILES	 := src/matjuice/Main.java src/matjuice/analysis/*.java src/matjuice/transformer/*.java src/matjuice/codegen/*.java src/matjuice/utils/*.java
 
-all:
+all: deps/mclab-core
 	mkdir -p $(BUILD_DIR)
 	mkdir -p $(GEN_DIR)
 	javac -g -d $(BUILD_DIR) $(PRETTY_FILES)
@@ -32,6 +32,9 @@ all:
 	@echo "$$MATJUICE_SCRIPT" > $(MATJUICE_SH)
 	chmod +x $(MATJUICE_SH)
 
+deps/mclab-core:
+	echo "Missing mclab-core dependency"
+	exit 1
 
 clean:
 	rm -rf $(BUILD_DIR) $(GEN_DIR) $(MATJUICE_JAR) $(MATJUICE_SH)

--- a/compiler.json
+++ b/compiler.json
@@ -1,0 +1,20 @@
+{
+    "type": "compiler",
+    "short-name":"matjuice",
+    "supported-languages":[
+        "matlab"
+    ],
+    "target-languages":[
+        "js"
+    ],
+    "runner-name":"runner.js",
+    "commands": [
+        {   "executable-path": { "file": "./matjuice.sh" },
+            "options":[
+                { "config": "/implementation/runner-source-file" },
+                { "config": "/compiler/runner-name" },
+                { "config": "/implementation/runner-argument-types"}
+            ]
+        }
+    ]
+}

--- a/src/matjuice/lib/lib.sjs
+++ b/src/matjuice/lib/lib.sjs
@@ -15,6 +15,9 @@ function nanIndex(xs) {
 
 var MC_COLON = {};
 var MC_TICTOC = 0;
+if (typeof performance === "undefined") {
+    var performance = Date;
+}
 
 function mc_error(msg) {
     throw msg;
@@ -831,11 +834,11 @@ function mc_min(a, b) {
 
 
 function mc_tic() {
-    MC_TICTOC = Date.now();
+    MC_TICTOC = performance.now();
 }
 
 function mc_toc() {
-    var elapsed = Date.now() - MC_TICTOC;
+    var elapsed = performance.now() - MC_TICTOC;
     return elapsed / 1000;
 }
 


### PR DESCRIPTION
That enables the matjuice compiler to be used with the Sable/Ostrich2 benchmark suite. So far only the 'bubble' benchmark can be compiled. 

How to test:
1. Install the Sable/wu-wei-benchmarking-toolkit
2. Install the Sable/Ostrich2 suite
3. From within the 'compilers' directory, clone the matjuice repository, install dependencies, 'make' then enjoy free support for Safari, Chrome, and Firefox :-)
